### PR TITLE
Promote develop → main: example clippy cleanup

### DIFF
--- a/crates/skia-rs-safe/examples/gpu_rendering.rs
+++ b/crates/skia-rs-safe/examples/gpu_rendering.rs
@@ -57,7 +57,7 @@ fn main() {
 
                 match context.create_surface(&props) {
                     Ok(mut surface) => {
-                        println!("\nCreated {}x{} GPU surface", width, height);
+                        println!("\nCreated {width}x{height} GPU surface");
 
                         // Clear with a gradient-like pattern (we'll do multiple clears)
                         // Since we don't have a full GPU drawing pipeline yet,
@@ -81,17 +81,17 @@ fn main() {
                             let g = pixels[1];
                             let b = pixels[2];
                             let a = pixels[3];
-                            println!("First pixel: rgba({}, {}, {}, {})", r, g, b, a);
+                            println!("First pixel: rgba({r}, {g}, {b}, {a})");
 
                             // Save to file
                             let output_path = "gpu_rendering_output.png";
                             let file =
                                 File::create(output_path).expect("Failed to create output file");
-                            let ref mut writer = BufWriter::new(file);
+                            let mut writer = BufWriter::new(file);
 
                             let img_info = ImageInfo::new(
-                                width as i32,
-                                height as i32,
+                                i32::try_from(width).expect("width fits in i32"),
+                                i32::try_from(height).expect("height fits in i32"),
                                 ColorType::Rgba8888,
                                 AlphaType::Opaque,
                             );
@@ -101,9 +101,9 @@ fn main() {
                             ) {
                                 let encoder = PngEncoder::new();
                                 encoder
-                                    .encode(&image, writer)
+                                    .encode(&image, &mut writer)
                                     .expect("Failed to encode PNG");
-                                println!("\nSaved output to: {}", output_path);
+                                println!("\nSaved output to: {output_path}");
                             }
                         } else {
                             eprintln!("Failed to read pixels from GPU surface");
@@ -115,12 +115,12 @@ fn main() {
                         println!("\nGPU operations complete");
                     }
                     Err(e) => {
-                        eprintln!("Failed to create GPU surface: {:?}", e);
+                        eprintln!("Failed to create GPU surface: {e:?}");
                     }
                 }
             }
             Err(e) => {
-                eprintln!("Failed to create GPU context: {:?}", e);
+                eprintln!("Failed to create GPU context: {e:?}");
                 eprintln!("This may be because no compatible GPU is available.");
                 eprintln!(
                     "The example will exit, but this is expected on systems without GPU support."

--- a/crates/skia-rs-safe/examples/pdf_generator.rs
+++ b/crates/skia-rs-safe/examples/pdf_generator.rs
@@ -19,6 +19,10 @@ fn main() {
 }
 
 #[cfg(feature = "pdf")]
+#[allow(
+    clippy::too_many_lines,
+    reason = "linear demo walkthrough; splitting into helpers would obscure the example"
+)]
 fn pdf_generator_main() {
     use skia_rs_core::{Color, Point, Rect};
     use skia_rs_paint::{Paint, Style};
@@ -47,10 +51,7 @@ fn pdf_generator_main() {
     let page_width = 612.0;
     let page_height = 792.0;
 
-    println!(
-        "\nBeginning page 1 ({}x{} points)...",
-        page_width, page_height
-    );
+    println!("\nBeginning page 1 ({page_width}x{page_height} points)...");
 
     let mut canvas = doc.begin_page(page_width, page_height);
     canvas.use_standard_font(skia_rs_pdf::StandardFont::Helvetica);
@@ -246,7 +247,7 @@ fn pdf_generator_main() {
         ];
 
         let mut y = 120.0;
-        for (name, color) in colors.iter() {
+        for (name, color) in &colors {
             let mut paint = Paint::new();
             paint.set_color32(*color);
             paint.set_style(Style::Fill);
@@ -274,7 +275,7 @@ fn pdf_generator_main() {
     let mut writer = BufWriter::new(file);
 
     doc.write_to(&mut writer).expect("Failed to write PDF");
-    println!("\nPDF saved to: {}", output_path);
+    println!("\nPDF saved to: {output_path}");
     println!("Total pages: {}", doc.page_count());
 
     println!("\nExample complete!");

--- a/crates/skia-rs-safe/examples/text_rendering.rs
+++ b/crates/skia-rs-safe/examples/text_rendering.rs
@@ -18,6 +18,10 @@ fn main() {
 }
 
 #[cfg(all(feature = "text", feature = "codec"))]
+#[allow(
+    clippy::too_many_lines,
+    reason = "linear demo walkthrough; splitting into helpers would obscure the example"
+)]
 fn text_rendering_main() {
     use skia_rs_canvas::Surface;
     use skia_rs_codec::{ImageEncoder, PngEncoder};
@@ -47,7 +51,7 @@ fn text_rendering_main() {
 
     // Title
     {
-        let font = Font::new(typeface.clone(), 48.0);
+        let font = Font::new(typeface, 48.0);
         let mut paint = Paint::new();
         paint.set_anti_alias(true);
         paint.set_color32(Color::from_rgb(30, 30, 50));
@@ -85,7 +89,7 @@ fn text_rendering_main() {
             let font = Font::from_size(size);
             paint.set_color32(Color::from_rgb(50, 50, 70));
 
-            let text = format!("Font size: {:.0}pt - The quick brown fox jumps", size);
+            let text = format!("Font size: {size:.0}pt - The quick brown fox jumps");
             let blob = TextBlob::from_text(&text, &font, Point::zero());
             canvas.draw_text_blob(&blob, 50.0, y, &paint);
 
@@ -204,12 +208,12 @@ fn text_rendering_main() {
 
     // Save to file
     let pixels = surface.pixels();
-    let stride = width as usize * 4;
+    let stride = usize::try_from(width).expect("width is non-negative") * 4;
 
     // Save using codec
     let output_path = "text_rendering_output.png";
     let file = File::create(output_path).expect("Failed to create output file");
-    let ref mut writer = BufWriter::new(file);
+    let mut writer = BufWriter::new(file);
 
     // Create image info and encode
     let img_info =
@@ -218,15 +222,12 @@ fn text_rendering_main() {
     if let Some(image) = skia_rs_codec::Image::from_raster_data(&img_info, pixels, stride) {
         let encoder = PngEncoder::new();
         encoder
-            .encode(&image, writer)
+            .encode(&image, &mut writer)
             .expect("Failed to encode PNG");
-        println!("\nSaved output to: {}", output_path);
+        println!("\nSaved output to: {output_path}");
     } else {
         eprintln!("Failed to create image from surface pixels");
     }
 
     println!("\nExample complete!");
 }
-
-#[cfg(all(feature = "text", feature = "codec"))]
-use skia_rs_canvas::Canvas;


### PR DESCRIPTION
Promotes the `--all-features` example clippy cleanup (PR #10) from `develop` to `main`.

Single functional change since the last release: the three `skia-rs-safe` feature-gated examples (`gpu_rendering`, `pdf_generator`, `text_rendering`) are now free of pedantic/nursery warnings under `--all-features`. See #10 for the full breakdown.

No library or API changes; examples only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)