### PR TITLE
Release v0.3.0 → main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,17 @@ jobs:
 
           echo "Tag version: $TAG_VERSION"
 
-          # Check each crate's version matches
+          # Check each crate's version matches. Crates inherit the version
+          # from the workspace via `version.workspace = true`, so treat that
+          # line as "workspace" (already validated above) rather than trying
+          # to parse a literal out of it.
           for cargo in crates/*/Cargo.toml; do
-            CRATE_VERSION=$(grep '^version' "$cargo" | head -1 | sed 's/.*"\(.*\)".*/\1/' || echo "workspace")
+            VERSION_LINE=$(grep '^version' "$cargo" | head -1)
+            if [ -z "$VERSION_LINE" ] || echo "$VERSION_LINE" | grep -q 'workspace'; then
+              CRATE_VERSION="workspace"
+            else
+              CRATE_VERSION=$(echo "$VERSION_LINE" | sed 's/.*"\(.*\)".*/\1/')
+            fi
             if [ "$CRATE_VERSION" != "workspace" ] && [ "$CRATE_VERSION" != "$TAG_VERSION" ]; then
               echo "Version mismatch in $cargo: $CRATE_VERSION != $TAG_VERSION"
               exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-12
+
 This release lands a large conformance audit against upstream C++ Skia. It
 contains **breaking** behavior and C-ABI changes across most crates (marked
 **Breaking** below); consumers should treat it as a minor-version bump
-(target **0.3.0**) despite the 0.x line, and C consumers must rebuild against
-the regenerated headers.
+despite the 0.x line, and C consumers must rebuild against the regenerated
+headers.
+
+It also folds the node/python bindings into the workspace, hardens CI
+(formatting baseline, Windows N32/BGRA coverage, toolchain setup), and
+enforces `clippy::pedantic` + `clippy::nursery` with `-D warnings`
+workspace-wide (including the `--all-features` examples).
 
 **Known limitations shipped in this release:**
 - **Windows raster surfaces:** `ColorType::n32()` now selects `Bgra8888` on
@@ -1101,5 +1108,6 @@ The first public release of skia-rs, a pure Rust implementation of the Skia 2D g
 
 
 [0.1.0]: https://github.com/pegasusheavy/skia-rs/releases/tag/v0.1.0
-[Unreleased]: https://github.com/pegasusheavy/skia-rs/compare/v0.1.0...HEAD
+[0.3.0]: https://github.com/quinnjr/skia-rs/compare/v0.2.7...v0.3.0
+[Unreleased]: https://github.com/quinnjr/skia-rs/compare/v0.3.0...HEAD
 

--- a/crates/skia-rs-canvas/src/raster.rs
+++ b/crates/skia-rs-canvas/src/raster.rs
@@ -119,7 +119,7 @@ impl PixelBuffer {
     /// Blend a **premultiplied** pixel at (x, y) using the given blend mode.
     ///
     /// `src` must already be premultiplied; the buffer stores premultiplied
-    /// pixels, and [`blend_colors`] operates on premultiplied inputs.
+    /// pixels, and `blend_colors` operates on premultiplied inputs.
     #[inline]
     pub fn blend_pixel(&mut self, x: i32, y: i32, src: Color, blend_mode: BlendMode) {
         if x < 0 || x >= self.width || y < 0 || y >= self.height {
@@ -898,7 +898,7 @@ impl<'a> Rasterizer<'a> {
     /// so translucent paints are blended exactly once per pixel — the old
     /// midpoint-octant loop emitted overlapping rows.
     ///
-    /// Assumes a translate + uniform-scale CTM; [`draw_circle`] routes any
+    /// Assumes a translate + uniform-scale CTM; [`draw_circle`](Self::draw_circle) routes any
     /// other matrix through the path pipeline.
     pub fn fill_circle(&mut self, center: Point, radius: Scalar, paint: &Paint) {
         use skia_rs_core::cast::{ceil_to_i32, floor_to_i32, round_to_i32, scalar_from_i32};

--- a/crates/skia-rs-codec/src/animation.rs
+++ b/crates/skia-rs-codec/src/animation.rs
@@ -6,7 +6,7 @@
 //! list themselves and composite according to the disposal and blend
 //! methods — the codec layer does not maintain a playback state machine.
 //!
-//! Only GIF is wired up here today (via [`GifCodec::decode_animated`]).
+//! Only GIF is wired up here today (via `GifDecoder::decode_animated`).
 //! APNG and animated WebP share the same shape and will plug into the
 //! same types once their decoders surface multi-frame data.
 

--- a/crates/skia-rs-ffi/include/skia_rs.h
+++ b/crates/skia-rs-ffi/include/skia_rs.h
@@ -73,21 +73,6 @@
 // Perspective 2 index.
 #define Matrix_PERSP_2 8
 
-// Filter mode for image sampling.
-enum FilterMode
-#ifdef __cplusplus
-  : uint8_t
-#endif // __cplusplus
- {
-    // Nearest neighbor sampling.
-    FilterMode_Nearest = 0,
-    // Bilinear interpolation.
-    FilterMode_Linear,
-};
-#ifndef __cplusplus
-typedef uint8_t FilterMode;
-#endif // __cplusplus
-
 // Mipmap mode for image sampling.
 enum MipmapMode
 #ifdef __cplusplus
@@ -103,6 +88,21 @@ enum MipmapMode
 };
 #ifndef __cplusplus
 typedef uint8_t MipmapMode;
+#endif // __cplusplus
+
+// Filter mode for image sampling.
+enum FilterMode
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+    // Nearest neighbor sampling.
+    FilterMode_Nearest = 0,
+    // Bilinear interpolation.
+    FilterMode_Linear,
+};
+#ifndef __cplusplus
+typedef uint8_t FilterMode;
 #endif // __cplusplus
 
 // Describes the color space for interpreting colors.
@@ -139,16 +139,16 @@ typedef struct sk_path_iter_t sk_path_iter_t;
 
 // Opaque picture recorder. Not reference counted — single ownership.
 //
-// The FFI recorder does not use the workspace [`PictureRecorder`] directly
+// The FFI recorder does not use the workspace [`PictureRecorder`](skia_rs_canvas::PictureRecorder) directly
 // because that type's recording API returns an unboxed mutable reference
 // that cannot cross the FFI boundary cleanly. Instead we track our own
-// [`DrawCommand`] stream and wrap it into a [`Picture`] at finish time,
-// calling [`Picture::from_parts`].
+// [`DrawCommand`](skia_rs_canvas::DrawCommand) stream and wrap it into a [`Picture`](skia_rs_canvas::Picture) at finish time,
+// calling [`Picture::from_parts`](skia_rs_canvas::Picture::from_parts).
 typedef struct sk_picture_recorder_t sk_picture_recorder_t;
 
 // Recording canvas handle. Returned by
 // [`sk_picture_recorder_begin_recording`] and accepted by
-// [`sk_recording_canvas_*`] — it is **not** interchangeable with
+// `sk_recording_canvas_*` — it is **not** interchangeable with
 // [`sk_canvas_t`] (which is raster-backed).
 typedef struct sk_recording_canvas_t sk_recording_canvas_t;
 
@@ -240,7 +240,7 @@ typedef struct sk_matrix_t {
 // C ABI type for [`SkClipOp`].
 //
 // Functions taking a clip op accept this raw `uint32_t` and decode it via
-// [`decode_clip_op`], rejecting out-of-range values instead of constructing
+// `decode_clip_op`, rejecting out-of-range values instead of constructing
 // an invalid Rust enum from C.
 typedef uint32_t sk_clip_op_t;
 
@@ -277,19 +277,19 @@ typedef struct RefCounted_ColorSpace sk_colorspace_t;
 // Reference counted [`TextBlob`].
 typedef struct RefCounted_TextBlob sk_textblob_t;
 
-// Reference counted [`Picture`].
+// Reference counted [`Picture`](skia_rs_canvas::Picture).
 typedef struct RefCounted_PictureRef sk_picture_t;
 
 // Reference counted [`Region`].
 typedef struct RefCounted_Region sk_region_t;
 
-// C ABI type for [`SkRegionOp`]; see [`decode_region_op`].
+// C ABI type for [`SkRegionOp`]; see `decode_region_op`.
 typedef uint32_t sk_region_op_t;
 
 // Reference counted [`PathEffectRef`].
 typedef struct RefCounted_PathEffectRef sk_patheffect_t;
 
-// C ABI type for [`SkTrimMode`]; see [`decode_trim_mode`].
+// C ABI type for [`SkTrimMode`]; see `decode_trim_mode`.
 typedef uint32_t sk_trim_mode_t;
 
 // Binary-compatible 2D point (matches `SkPoint` exactly)
@@ -833,11 +833,11 @@ int32_t sk_canvas_save(struct sk_canvas_t *canvas);
 //
 // Both `bounds` and `paint` are optional (null is acceptable). The layer
 // is allocated lazily (at the next draw) because draws go through the
-// transient [`Canvas`] layer machinery already. Returns the new save count,
+// transient [`Canvas`](skia_rs_canvas::Canvas) layer machinery already. Returns the new save count,
 // or 0 on failure (null canvas).
 //
 // **Pragmatic note:** because the FFI canvas reconstructs its underlying
-// [`Canvas`] between calls, the `layer_paint` / `layer_bounds` are tracked but
+// [`Canvas`](skia_rs_canvas::Canvas) between calls, the `layer_paint` / `layer_bounds` are tracked but
 // composition is delegated to the transient canvas at the next draw — the
 // effective behavior matches the recording-only semantics in
 // [`skia_rs_canvas::Canvas::save_layer`].
@@ -885,7 +885,7 @@ void sk_canvas_draw_path(struct sk_canvas_t *canvas,
 // Intersect or subtract a rectangle from the clip.
 //
 // `op` follows upstream `SkClipOp`: 0 = Difference, 1 = Intersect (see
-// [`decode_clip_op`]). Returns false if the canvas handle is null or `op`
+// `decode_clip_op`). Returns false if the canvas handle is null or `op`
 // is out of range; otherwise true.
 bool sk_canvas_clip_rect(struct sk_canvas_t *canvas,
                          const struct sk_rect_t *rect,
@@ -894,7 +894,7 @@ bool sk_canvas_clip_rect(struct sk_canvas_t *canvas,
 
 // Intersect or subtract a path from the clip.
 //
-// `op` follows upstream `SkClipOp`; see [`decode_clip_op`]. Returns false
+// `op` follows upstream `SkClipOp`; see `decode_clip_op`. Returns false
 // if `op` is out of range.
 bool sk_canvas_clip_path(struct sk_canvas_t *canvas,
                          const sk_path_t *path,
@@ -1225,7 +1225,7 @@ bool sk_region_set_rect(sk_region_t *region,
 
 // Apply a rect op on the region.
 //
-// `op` follows upstream `SkRegion::Op`; see [`decode_region_op`]. Returns
+// `op` follows upstream `SkRegion::Op`; see `decode_region_op`. Returns
 // false if `op` is out of range.
 bool sk_region_op_rect(sk_region_t *region,
                        const struct sk_irect_t *rect,
@@ -1261,7 +1261,7 @@ sk_patheffect_t *sk_patheffect_new_dash(const float *intervals,
 
 // Create a trim path effect. `start` and `end` are normalized lengths
 // in [0, 1]. `mode` follows upstream `SkTrimPathEffect::Mode`; see
-// [`decode_trim_mode`]. Returns null if `mode` is out of range.
+// `decode_trim_mode`. Returns null if `mode` is out of range.
 sk_patheffect_t *sk_patheffect_new_trim(float start,
                                         float end,
                                         sk_trim_mode_t mode);

--- a/crates/skia-rs-ffi/src/lib.rs
+++ b/crates/skia-rs-ffi/src/lib.rs
@@ -284,7 +284,7 @@ use skia_rs_text::{Font, TextBlob, Typeface, TypefaceRef};
 /// plain `uint32_t` (see [`sk_clip_op_t`]) rather than a Rust-repr enum
 /// parameter, because an out-of-range value received directly into a Rust
 /// `#[repr(u32)] enum` parameter is undefined behavior; functions that take
-/// a clip op decode the raw integer via [`decode_clip_op`] instead.
+/// a clip op decode the raw integer via `decode_clip_op` instead.
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SkClipOp {
@@ -297,7 +297,7 @@ pub enum SkClipOp {
 /// C ABI type for [`SkClipOp`].
 ///
 /// Functions taking a clip op accept this raw `uint32_t` and decode it via
-/// [`decode_clip_op`], rejecting out-of-range values instead of constructing
+/// `decode_clip_op`, rejecting out-of-range values instead of constructing
 /// an invalid Rust enum from C.
 pub type sk_clip_op_t = u32;
 
@@ -315,7 +315,7 @@ const fn decode_clip_op(v: sk_clip_op_t) -> Option<ClipOp> {
 ///
 /// Numeric values match upstream `SkRegion::Op` (`include/core/SkRegion.h`).
 /// Exposed to C as a raw `uint32_t` (see [`sk_region_op_t`]) and decoded via
-/// [`decode_region_op`], which rejects out-of-range values.
+/// `decode_region_op`, which rejects out-of-range values.
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SkRegionOp {
@@ -333,7 +333,7 @@ pub enum SkRegionOp {
     Replace = 5,
 }
 
-/// C ABI type for [`SkRegionOp`]; see [`decode_region_op`].
+/// C ABI type for [`SkRegionOp`]; see `decode_region_op`.
 pub type sk_region_op_t = u32;
 
 /// Decode a raw `sk_region_op_t` into [`RegionOp`]. Returns `None` for any
@@ -355,7 +355,7 @@ const fn decode_region_op(v: sk_region_op_t) -> Option<RegionOp> {
 /// Numeric values match upstream `SkTrimPathEffect::Mode`
 /// (`include/effects/SkTrimPathEffect.h`): `kNormal = 0`, `kInverted = 1`.
 /// Exposed to C as a raw `uint32_t` (see [`sk_trim_mode_t`]) and decoded via
-/// [`decode_trim_mode`], which rejects out-of-range values.
+/// `decode_trim_mode`, which rejects out-of-range values.
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SkTrimMode {
@@ -365,7 +365,7 @@ pub enum SkTrimMode {
     Inverted = 1,
 }
 
-/// C ABI type for [`SkTrimMode`]; see [`decode_trim_mode`].
+/// C ABI type for [`SkTrimMode`]; see `decode_trim_mode`.
 pub type sk_trim_mode_t = u32;
 
 /// Decode a raw `sk_trim_mode_t` into [`TrimMode`]. Returns `None` for any
@@ -1951,11 +1951,11 @@ pub unsafe extern "C" fn sk_canvas_save(canvas: *mut sk_canvas_t) -> i32 {
 ///
 /// Both `bounds` and `paint` are optional (null is acceptable). The layer
 /// is allocated lazily (at the next draw) because draws go through the
-/// transient [`Canvas`] layer machinery already. Returns the new save count,
+/// transient [`Canvas`](skia_rs_canvas::Canvas) layer machinery already. Returns the new save count,
 /// or 0 on failure (null canvas).
 ///
 /// **Pragmatic note:** because the FFI canvas reconstructs its underlying
-/// [`Canvas`] between calls, the `layer_paint` / `layer_bounds` are tracked but
+/// [`Canvas`](skia_rs_canvas::Canvas) between calls, the `layer_paint` / `layer_bounds` are tracked but
 /// composition is delegated to the transient canvas at the next draw — the
 /// effective behavior matches the recording-only semantics in
 /// [`skia_rs_canvas::Canvas::save_layer`].
@@ -2097,7 +2097,7 @@ pub unsafe extern "C" fn sk_canvas_draw_path(
 /// Intersect or subtract a rectangle from the clip.
 ///
 /// `op` follows upstream `SkClipOp`: 0 = Difference, 1 = Intersect (see
-/// [`decode_clip_op`]). Returns false if the canvas handle is null or `op`
+/// `decode_clip_op`). Returns false if the canvas handle is null or `op`
 /// is out of range; otherwise true.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sk_canvas_clip_rect(
@@ -2127,7 +2127,7 @@ pub unsafe extern "C" fn sk_canvas_clip_rect(
 
 /// Intersect or subtract a path from the clip.
 ///
-/// `op` follows upstream `SkClipOp`; see [`decode_clip_op`]. Returns false
+/// `op` follows upstream `SkClipOp`; see `decode_clip_op`. Returns false
 /// if `op` is out of range.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sk_canvas_clip_path(
@@ -2954,16 +2954,16 @@ pub unsafe extern "C" fn sk_canvas_draw_text_blob(
 // Picture / PictureRecorder API
 // =============================================================================
 
-/// Reference counted [`Picture`].
+/// Reference counted [`Picture`](skia_rs_canvas::Picture).
 pub type sk_picture_t = RefCounted<PictureRef>;
 
 /// Opaque picture recorder. Not reference counted — single ownership.
 ///
-/// The FFI recorder does not use the workspace [`PictureRecorder`] directly
+/// The FFI recorder does not use the workspace [`PictureRecorder`](skia_rs_canvas::PictureRecorder) directly
 /// because that type's recording API returns an unboxed mutable reference
 /// that cannot cross the FFI boundary cleanly. Instead we track our own
-/// [`DrawCommand`] stream and wrap it into a [`Picture`] at finish time,
-/// calling [`Picture::from_parts`].
+/// [`DrawCommand`](skia_rs_canvas::DrawCommand) stream and wrap it into a [`Picture`](skia_rs_canvas::Picture) at finish time,
+/// calling [`Picture::from_parts`](skia_rs_canvas::Picture::from_parts).
 pub struct sk_picture_recorder_t {
     /// Accumulated draw commands while recording. Swapped out on finish.
     commands: Vec<skia_rs_canvas::DrawCommand>,
@@ -3013,7 +3013,7 @@ pub unsafe extern "C" fn sk_picture_recorder_delete(r: *mut sk_picture_recorder_
 
 /// Recording canvas handle. Returned by
 /// [`sk_picture_recorder_begin_recording`] and accepted by
-/// [`sk_recording_canvas_*`] — it is **not** interchangeable with
+/// `sk_recording_canvas_*` — it is **not** interchangeable with
 /// [`sk_canvas_t`] (which is raster-backed).
 pub struct sk_recording_canvas_t {
     /// Points back to the owning recorder. The recorder outlives the
@@ -3302,7 +3302,7 @@ pub unsafe extern "C" fn sk_region_set_rect(
 
 /// Apply a rect op on the region.
 ///
-/// `op` follows upstream `SkRegion::Op`; see [`decode_region_op`]. Returns
+/// `op` follows upstream `SkRegion::Op`; see `decode_region_op`. Returns
 /// false if `op` is out of range.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sk_region_op_rect(
@@ -3408,7 +3408,7 @@ pub unsafe extern "C" fn sk_patheffect_new_dash(
 
 /// Create a trim path effect. `start` and `end` are normalized lengths
 /// in [0, 1]. `mode` follows upstream `SkTrimPathEffect::Mode`; see
-/// [`decode_trim_mode`]. Returns null if `mode` is out of range.
+/// `decode_trim_mode`. Returns null if `mode` is out of range.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sk_patheffect_new_trim(
     start: f32,

--- a/crates/skia-rs-gpu/src/opengl_backend.rs
+++ b/crates/skia-rs-gpu/src/opengl_backend.rs
@@ -567,7 +567,10 @@ impl GLPolygonMode {
 }
 
 /// OpenGL-based GPU context.
+// Cached binding state (`current_vao`/`current_program`/`current_framebuffer`)
+// is retained for future state-tracking use even when not read directly.
 #[cfg(feature = "opengl")]
+#[allow(dead_code)]
 pub struct OpenGLContext {
     /// Glow context.
     gl: glow::Context,

--- a/crates/skia-rs-gpu/src/vulkan_backend.rs
+++ b/crates/skia-rs-gpu/src/vulkan_backend.rs
@@ -374,7 +374,10 @@ pub fn vk_format_to_texture(format: vk::Format) -> Option<TextureFormat> {
 }
 
 /// Vulkan-based GPU context.
+// Handle/state fields (e.g. `entry`, queue-family indices) are retained to
+// keep Vulkan objects alive or for future use even when not read directly.
 #[cfg(feature = "vulkan")]
+#[allow(dead_code)]
 pub struct VulkanContext {
     /// Vulkan entry point.
     entry: ash::Entry,

--- a/crates/skia-rs-gpu/src/wgpu_backend.rs
+++ b/crates/skia-rs-gpu/src/wgpu_backend.rs
@@ -17,6 +17,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 /// wgpu-based GPU context.
+// Some fields (e.g. `instance`, `adapter`) are retained to keep the
+// underlying wgpu handles alive for the lifetime of the context even though
+// they are not read directly.
+#[allow(dead_code)]
 pub struct WgpuContext {
     instance: wgpu::Instance,
     adapter: wgpu::Adapter,
@@ -169,6 +173,8 @@ impl GpuContext for WgpuContext {
 }
 
 /// wgpu-based GPU surface.
+// `staging_buffer` is retained for readback reuse and is not always read.
+#[allow(dead_code)]
 pub struct WgpuSurface {
     device: Arc<wgpu::Device>,
     queue: Arc<wgpu::Queue>,

--- a/crates/skia-rs-paint/src/paint.rs
+++ b/crates/skia-rs-paint/src/paint.rs
@@ -412,9 +412,9 @@ impl Paint {
     /// - 1 byte: stroke cap
     /// - 1 byte: stroke join
     /// - 1 byte: flags (bit 0: `anti_alias`, bit 1: dither)
-    /// - [optional trailing sections for shader, `mask_filter`, `color_filter`, `image_filter`]
+    /// - \[optional trailing sections for shader, `mask_filter`, `color_filter`, `image_filter`\]
     ///
-    /// Each optional section is: [1 byte present flag] [4 bytes length] [data].
+    /// Each optional section is: \[1 byte present flag\] \[4 bytes length\] \[data\].
     /// If a shader/filter does not support serialization (e.g., runtime shaders), the
     /// present flag is 0 and that field is omitted from deserialization.
     #[must_use]

--- a/crates/skia-rs-paint/src/sksl_validate.rs
+++ b/crates/skia-rs-paint/src/sksl_validate.rs
@@ -44,7 +44,7 @@
 //!   without bounds checking.
 //!
 //! The hook point is [`validate_program`], called from
-//! [`crate::runtime_effect::RuntimeEffect::compile`] after
+//! `crate::runtime_effect::RuntimeEffect::compile` after
 //! `validate_entry_point` so callers see a single coherent validation
 //! pass.
 

--- a/crates/skia-rs-pdf/src/canvas.rs
+++ b/crates/skia-rs-pdf/src/canvas.rs
@@ -410,16 +410,16 @@ impl<'a> PdfCanvas<'a> {
         self.stroke_or_fill(paint, even_odd);
     }
 
-    /// Draw text using the currently selected font (see [`set_font`]).
+    /// Draw text using the currently selected font (see [`set_font`](Self::set_font)).
     ///
     /// Returns `Err(PdfError::Unsupported)` if no font is selected; use
-    /// [`draw_text_with_font`] to provide one explicitly.
+    /// [`draw_text_with_font`](Self::draw_text_with_font) to provide one explicitly.
     ///
     /// # Errors
     ///
     /// Returns `Err(PdfError::Unsupported)` if no font is currently
     /// selected, or if the selected font is a Type0/CID font (see
-    /// [`draw_text_with_font`]).
+    /// [`draw_text_with_font`](Self::draw_text_with_font)).
     pub fn draw_text(
         &mut self,
         text: &str,
@@ -556,8 +556,8 @@ impl<'a> PdfCanvas<'a> {
     /// Draw a PDF image registered with the document's image manager.
     ///
     /// The image is painted at the given position at its natural size in
-    /// user-space units (1 unit == 1/72 inch). Use [`concat`] or [`save`]/
-    /// [`restore`] to scale as needed.
+    /// user-space units (1 unit == 1/72 inch). Use [`concat`](Self::concat) or
+    /// [`save`](Self::save)/[`restore`](Self::restore) to scale as needed.
     ///
     /// # Panics
     ///

--- a/crates/skia-rs-python/Cargo.toml
+++ b/crates/skia-rs-python/Cargo.toml
@@ -15,6 +15,11 @@ readme = "README.md"
 [lib]
 name = "skia_rs"
 crate-type = ["cdylib"]
+# This is a PyO3 extension module whose lib name (`skia_rs`, the importable
+# Python module) intentionally matches the umbrella crate. rustdoc emits both
+# to the same `skia_rs` path, which collides under `cargo doc --workspace`.
+# The Rust docs for the extension glue are not useful, so exclude it.
+doc = false
 
 [features]
 png = []

--- a/crates/skia-rs-svg/src/glyph_svg.rs
+++ b/crates/skia-rs-svg/src/glyph_svg.rs
@@ -73,7 +73,7 @@ pub fn glyph_svg_to_dom(raw: &[u8]) -> Option<SvgDom> {
 ///
 /// This is the convenience entry point that ties together
 /// [`Font::glyph_svg`] (read the table), [`glyph_svg_to_dom`] (decode +
-/// parse), and [`render_svg`] (rasterise). It is the SVG-glyph
+/// parse), and [`render_svg`](crate::render::render_svg) (rasterise). It is the SVG-glyph
 /// counterpart to `Canvas::draw_color_glyph`'s COLR path, kept in this
 /// crate to avoid a dependency cycle (skia-rs-svg already depends on
 /// skia-rs-canvas).

--- a/include/skia-rs.h
+++ b/include/skia-rs.h
@@ -73,21 +73,6 @@
 // Perspective 2 index.
 #define Matrix_PERSP_2 8
 
-// Filter mode for image sampling.
-enum FilterMode
-#ifdef __cplusplus
-  : uint8_t
-#endif // __cplusplus
- {
-    // Nearest neighbor sampling.
-    FilterMode_Nearest = 0,
-    // Bilinear interpolation.
-    FilterMode_Linear,
-};
-#ifndef __cplusplus
-typedef uint8_t FilterMode;
-#endif // __cplusplus
-
 // Mipmap mode for image sampling.
 enum MipmapMode
 #ifdef __cplusplus
@@ -103,6 +88,21 @@ enum MipmapMode
 };
 #ifndef __cplusplus
 typedef uint8_t MipmapMode;
+#endif // __cplusplus
+
+// Filter mode for image sampling.
+enum FilterMode
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+    // Nearest neighbor sampling.
+    FilterMode_Nearest = 0,
+    // Bilinear interpolation.
+    FilterMode_Linear,
+};
+#ifndef __cplusplus
+typedef uint8_t FilterMode;
 #endif // __cplusplus
 
 // Describes the color space for interpreting colors.
@@ -139,16 +139,16 @@ typedef struct sk_path_iter_t sk_path_iter_t;
 
 // Opaque picture recorder. Not reference counted — single ownership.
 //
-// The FFI recorder does not use the workspace [`PictureRecorder`] directly
+// The FFI recorder does not use the workspace [`PictureRecorder`](skia_rs_canvas::PictureRecorder) directly
 // because that type's recording API returns an unboxed mutable reference
 // that cannot cross the FFI boundary cleanly. Instead we track our own
-// [`DrawCommand`] stream and wrap it into a [`Picture`] at finish time,
-// calling [`Picture::from_parts`].
+// [`DrawCommand`](skia_rs_canvas::DrawCommand) stream and wrap it into a [`Picture`](skia_rs_canvas::Picture) at finish time,
+// calling [`Picture::from_parts`](skia_rs_canvas::Picture::from_parts).
 typedef struct sk_picture_recorder_t sk_picture_recorder_t;
 
 // Recording canvas handle. Returned by
 // [`sk_picture_recorder_begin_recording`] and accepted by
-// [`sk_recording_canvas_*`] — it is **not** interchangeable with
+// `sk_recording_canvas_*` — it is **not** interchangeable with
 // [`sk_canvas_t`] (which is raster-backed).
 typedef struct sk_recording_canvas_t sk_recording_canvas_t;
 
@@ -240,7 +240,7 @@ typedef struct sk_matrix_t {
 // C ABI type for [`SkClipOp`].
 //
 // Functions taking a clip op accept this raw `uint32_t` and decode it via
-// [`decode_clip_op`], rejecting out-of-range values instead of constructing
+// `decode_clip_op`, rejecting out-of-range values instead of constructing
 // an invalid Rust enum from C.
 typedef uint32_t sk_clip_op_t;
 
@@ -277,19 +277,19 @@ typedef struct RefCounted_ColorSpace sk_colorspace_t;
 // Reference counted [`TextBlob`].
 typedef struct RefCounted_TextBlob sk_textblob_t;
 
-// Reference counted [`Picture`].
+// Reference counted [`Picture`](skia_rs_canvas::Picture).
 typedef struct RefCounted_PictureRef sk_picture_t;
 
 // Reference counted [`Region`].
 typedef struct RefCounted_Region sk_region_t;
 
-// C ABI type for [`SkRegionOp`]; see [`decode_region_op`].
+// C ABI type for [`SkRegionOp`]; see `decode_region_op`.
 typedef uint32_t sk_region_op_t;
 
 // Reference counted [`PathEffectRef`].
 typedef struct RefCounted_PathEffectRef sk_patheffect_t;
 
-// C ABI type for [`SkTrimMode`]; see [`decode_trim_mode`].
+// C ABI type for [`SkTrimMode`]; see `decode_trim_mode`.
 typedef uint32_t sk_trim_mode_t;
 
 // Binary-compatible 2D point (matches `SkPoint` exactly)
@@ -833,11 +833,11 @@ int32_t sk_canvas_save(struct sk_canvas_t *canvas);
 //
 // Both `bounds` and `paint` are optional (null is acceptable). The layer
 // is allocated lazily (at the next draw) because draws go through the
-// transient [`Canvas`] layer machinery already. Returns the new save count,
+// transient [`Canvas`](skia_rs_canvas::Canvas) layer machinery already. Returns the new save count,
 // or 0 on failure (null canvas).
 //
 // **Pragmatic note:** because the FFI canvas reconstructs its underlying
-// [`Canvas`] between calls, the `layer_paint` / `layer_bounds` are tracked but
+// [`Canvas`](skia_rs_canvas::Canvas) between calls, the `layer_paint` / `layer_bounds` are tracked but
 // composition is delegated to the transient canvas at the next draw — the
 // effective behavior matches the recording-only semantics in
 // [`skia_rs_canvas::Canvas::save_layer`].
@@ -885,7 +885,7 @@ void sk_canvas_draw_path(struct sk_canvas_t *canvas,
 // Intersect or subtract a rectangle from the clip.
 //
 // `op` follows upstream `SkClipOp`: 0 = Difference, 1 = Intersect (see
-// [`decode_clip_op`]). Returns false if the canvas handle is null or `op`
+// `decode_clip_op`). Returns false if the canvas handle is null or `op`
 // is out of range; otherwise true.
 bool sk_canvas_clip_rect(struct sk_canvas_t *canvas,
                          const struct sk_rect_t *rect,
@@ -894,7 +894,7 @@ bool sk_canvas_clip_rect(struct sk_canvas_t *canvas,
 
 // Intersect or subtract a path from the clip.
 //
-// `op` follows upstream `SkClipOp`; see [`decode_clip_op`]. Returns false
+// `op` follows upstream `SkClipOp`; see `decode_clip_op`. Returns false
 // if `op` is out of range.
 bool sk_canvas_clip_path(struct sk_canvas_t *canvas,
                          const sk_path_t *path,
@@ -1225,7 +1225,7 @@ bool sk_region_set_rect(sk_region_t *region,
 
 // Apply a rect op on the region.
 //
-// `op` follows upstream `SkRegion::Op`; see [`decode_region_op`]. Returns
+// `op` follows upstream `SkRegion::Op`; see `decode_region_op`. Returns
 // false if `op` is out of range.
 bool sk_region_op_rect(sk_region_t *region,
                        const struct sk_irect_t *rect,
@@ -1261,7 +1261,7 @@ sk_patheffect_t *sk_patheffect_new_dash(const float *intervals,
 
 // Create a trim path effect. `start` and `end` are normalized lengths
 // in [0, 1]. `mode` follows upstream `SkTrimPathEffect::Mode`; see
-// [`decode_trim_mode`]. Returns null if `mode` is out of range.
+// `decode_trim_mode`. Returns null if `mode` is out of range.
 sk_patheffect_t *sk_patheffect_new_trim(float start,
                                         float end,
                                         sk_trim_mode_t mode);


### PR DESCRIPTION
Promotes **v0.3.0** to `main` for tagging/release.

Since the last promotion (#11) this adds the release-prep work (#12): CHANGELOG finalized to 0.3.0, `release.yml` validate fix, `--all-features` rustdoc gate cleared, `skia-rs-python` doc collision fixed, and regenerated C headers.

After merge, tagging `v0.3.0` on `main` triggers the release workflow (validate → build → crates.io publish + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)