### PR TITLE
ci(release): remove auto crates.io publish; fix validate native deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,6 @@ on:
     tags:
       - 'v[0-9]+.*'
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry run (do not publish)'
-        required: false
-        type: boolean
-        default: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -27,6 +21,13 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+
+      # `cargo test --all-features` builds the codec-avif feature, whose
+      # libaom-sys native build requires an assembler (nasm/yasm) and cmake.
+      - name: Install native build dependencies (avif/libaom)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nasm cmake
 
       - name: Check version consistency
         run: |
@@ -128,44 +129,9 @@ jobs:
           name: skia-rs-${{ matrix.target }}
           path: skia-rs-${{ matrix.target }}.tar.gz
 
-  # ==========================================================================
-  # Publish to crates.io
-  # ==========================================================================
-  publish:
-    name: Publish to crates.io
-    runs-on: ubuntu-latest
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/') && github.event.inputs.dry_run != 'true'
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Publish crates (in dependency order)
-        run: |
-          # Publish in dependency order
-          CRATES=(
-            "skia-rs-core"
-            "skia-rs-path"
-            "skia-rs-paint"
-            "skia-rs-codec"
-            "skia-rs-text"
-            "skia-rs-canvas"
-            "skia-rs-gpu"
-            "skia-rs-svg"
-            "skia-rs-pdf"
-            "skia-rs-ffi"
-            "skia-rs-safe"
-          )
-
-          for crate in "${CRATES[@]}"; do
-            echo "Publishing $crate..."
-            cargo publish -p "$crate" --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || true
-            sleep 30  # Wait for crates.io to process
-          done
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  # Publishing to crates.io is intentionally NOT automated here: it is always
+  # done manually from a maintainer-controlled host box. Do not add a
+  # `cargo publish` job to this workflow.
 
   # ==========================================================================
   # Create GitHub Release


### PR DESCRIPTION
Per maintainer direction, crates.io publishing is always done manually from a controlled host box — so:

- **Remove the automatic `Publish to crates.io` job** from `release.yml` entirely (drop the unused `dry_run` dispatch input). The workflow now only validates, builds artifacts, and creates the GitHub release.
- **Fix the `validate` job**: install `nasm` + `cmake` before `cargo test --all-features`. `--all-features` pulls `codec-avif` → `libaom-sys`, whose native build needs an assembler; without it CMake failed (`Unable to find assembler`, cascading to a `pie_check` failure) — which is why every tagged release run (v0.2.6, v0.2.7, and the initial v0.3.0 run) died in `validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)