### PR TITLE
Release workflow fixes → main (v0.3.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,6 @@ on:
     tags:
       - 'v[0-9]+.*'
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry run (do not publish)'
-        required: false
-        type: boolean
-        default: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -27,6 +21,13 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+
+      # `cargo test --all-features` builds the codec-avif feature, whose
+      # libaom-sys native build requires an assembler (nasm/yasm) and cmake.
+      - name: Install native build dependencies (avif/libaom)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nasm cmake
 
       - name: Check version consistency
         run: |
@@ -128,44 +129,9 @@ jobs:
           name: skia-rs-${{ matrix.target }}
           path: skia-rs-${{ matrix.target }}.tar.gz
 
-  # ==========================================================================
-  # Publish to crates.io
-  # ==========================================================================
-  publish:
-    name: Publish to crates.io
-    runs-on: ubuntu-latest
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/') && github.event.inputs.dry_run != 'true'
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Publish crates (in dependency order)
-        run: |
-          # Publish in dependency order
-          CRATES=(
-            "skia-rs-core"
-            "skia-rs-path"
-            "skia-rs-paint"
-            "skia-rs-codec"
-            "skia-rs-text"
-            "skia-rs-canvas"
-            "skia-rs-gpu"
-            "skia-rs-svg"
-            "skia-rs-pdf"
-            "skia-rs-ffi"
-            "skia-rs-safe"
-          )
-
-          for crate in "${CRATES[@]}"; do
-            echo "Publishing $crate..."
-            cargo publish -p "$crate" --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || true
-            sleep 30  # Wait for crates.io to process
-          done
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  # Publishing to crates.io is intentionally NOT automated here: it is always
+  # done manually from a maintainer-controlled host box. Do not add a
+  # `cargo publish` job to this workflow.
 
   # ==========================================================================
   # Create GitHub Release


### PR DESCRIPTION
Removes automatic crates.io publishing (done manually from a controlled host box) and fixes the release `validate` job's native deps (nasm/cmake for avif/libaom under `--all-features`). See #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)