### PR TITLE
ci(release): fetch Git LFS in validate checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,12 @@ jobs:
     name: Validate Release
     runs-on: ubuntu-latest
     steps:
+      # Test fixtures (fonts, images) are stored in Git LFS; without this the
+      # checkout leaves LFS pointer files and `include_bytes!` embeds the
+      # pointer text, so tests like text_glyph_rendering fail to parse them.
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
The release `validate` job's `cargo test --all-features` failed on `skia-rs-canvas text_glyph_rendering` — `Typeface::from_data(demo.ttf)` panicked. Root cause: font/image fixtures are Git LFS (`.gitattributes`), and `actions/checkout@v4` doesn't fetch LFS by default, so `include_bytes!` embedded the 128-byte LFS pointer instead of the font. Set `lfs: true`.

Verified full `cargo test --workspace --all-features` passes locally (0 failures) with real LFS fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)