### PR TITLE
Release workflow: LFS fetch in validate → main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,12 @@ jobs:
     name: Validate Release
     runs-on: ubuntu-latest
     steps:
+      # Test fixtures (fonts, images) are stored in Git LFS; without this the
+      # checkout leaves LFS pointer files and `include_bytes!` embeds the
+      # pointer text, so tests like text_glyph_rendering fail to parse them.
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Adds `lfs: true` to the release validate checkout so `cargo test --all-features` sees the real Git-LFS font/image fixtures instead of pointer files. See #16. Completes the release-workflow fixes for v0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)