### PR TITLE
ci: LFS fetch in ci/conformance/fuzz → main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -36,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -68,6 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          lfs: true
           submodules: recursive
 
       - uses: actions/setup-node@v4
@@ -103,6 +108,8 @@ jobs:
     continue-on-error: true  # MSRV check is advisory
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -122,6 +129,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -145,6 +154,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build benchmarks
@@ -162,6 +173,8 @@ jobs:
     continue-on-error: true  # Security audit is advisory
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run security audit
@@ -175,6 +188,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -252,6 +267,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          lfs: true
           submodules: recursive
 
       - uses: actions/setup-node@v4
@@ -356,6 +372,8 @@ jobs:
     if: always()
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Download all conformance results
         uses: actions/download-artifact@v4

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          lfs: true
           submodules: recursive
 
       - name: Cache Skia build
@@ -77,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -107,6 +110,8 @@ jobs:
     needs: [generate-reference, generate-output]
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Download reference images
         uses: actions/download-artifact@v4

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -48,6 +48,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - uses: dtolnay/rust-toolchain@nightly
         with:
@@ -103,6 +105,8 @@ jobs:
     if: always()
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Download all crash artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Adds `lfs: true` to ci/conformance/fuzz checkouts so all CI jobs build against real fixtures, not LFS pointers. See #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)